### PR TITLE
Fix typo in Zvmm32a16bf assembly mnemonic

### DIFF
--- a/isa/zvmm/zvmm.adoc
+++ b/isa/zvmm/zvmm.adoc
@@ -134,7 +134,7 @@ NOTE: Because most of the accumulation occurs using fixed-point carry-save arith
 mandating this scheme still offers some degree of implementation flexibility.
 
 ```
-vfmmacc.vv vd, vs2, vs1, ci, vm
+vfwmmacc.vv vd, vs2, vs1, ci, vm
 ```
 
 ```wavedrom


### PR DESCRIPTION
I assume this was supposed to match the text in the first paragraph.