### PR TITLE
VME tweaks

### DIFF
--- a/isa/zvt/zvt.adoc
+++ b/isa/zvt/zvt.adoc
@@ -92,10 +92,18 @@ efficient transpose of matrices of those datatypes using the tile storage.
 
 === Matrix Tile State
 
-The new matrix state is organized into _tiles_, where a tile is a
+The new matrix state is organized into _matrix tiles_, where a matrix tile is a
 separately addressable two-dimensional square matrix.  The
 fixed matrix state is viewed as a different number of tiles, depending
 on TEW.
+
+[NOTE]
+====
+For brevity, we use the term _tile_ as shorthand for matrix tile.
+We considered instead naming these tiles _accumulator tiles_, but
+chose not to do so because they are used for other purposes, including
+matrix transposition.
+====
 
 The ISA is optimized for the case where TEW=32, as this is the most
 common accumulator size.  When TEW=32, the tiles have dimensions TExTE

--- a/isa/zvt/zvt.adoc
+++ b/isa/zvt/zvt.adoc
@@ -116,7 +116,7 @@ more flexible usage of tile accumulators enabling optimizations such
 as register blocking of the operands, reducing memory traffic.
 
 ----
-Tile EEW  #Tiles Tile Dimensions Tile Specifiers
+Tile EEW  NTiles Tile Dimensions Tile Specifiers
   8        16        TExTE       mt0,mt1,        ...,          mt14,mt15
  16         8        TExTE       mt0,mt2,mt4,mt6,mt8,mt10,mt12,mt14
  32         4        TExTE       mt0,    mt4,    mt8,     mt12
@@ -149,7 +149,7 @@ NOTE: The accumulator array dimensions (TE) may be determined dynamically with
 the `msettn` instruction to enable writing TE-agnostic software.
 
 ==== Tile Punning
-The tile state is reshaped for each supported TEW which results in
+The matrix tile state is reshaped for each supported TEW which results in
 tiles being combined to support wider accumulators. For example,
 4 TEW=8 tiles (mt0..3) are combined to support a single TEW=32 tile
 (mt0).
@@ -366,7 +366,7 @@ if mtype.mtwiden != 0:
   let ETE = TEW < 64 ? TE : TE/2 // Effective number of elements along tile edge
   let EVE = VLEN/SEW             // Effective number of elements in a vector register
 
-  vtype.vlmul = lg(min(8/KMAX, 8/TWIDEN, ceil(ETE/EVE)))
+  vtype.vlmul = log2(min(8/KMAX, 8/TWIDEN, ceil(ETE/EVE)))
                         ^        ^           ^
                         |        |           +-matrix engine size constraint
                         |        +-matrix row/col must fit in vector register group
@@ -491,7 +491,7 @@ SEW  TWIDEN  KMAX
 
 === Tile Subset Specifier (TSS)
 
-For operations that move rows or columns between the tiles and vector
+For operations that move rows or columns between the matrix tiles and vector
 registers or memory, a scalar value is used to encode the set of tile
 elements that are accessed and the pattern by which they are accessed.
 
@@ -504,7 +504,7 @@ XLEN-1:31  reserved
 ----
 
 When there are fewer than 16 tiles due to the specified TEW, the
-`log2(16 / #Tiles)` LSBs of the tile-specifier field are ignored,
+`log2(16 / NTiles)` LSBs of the tile-specifier field are ignored,
 such that this field always refers to a valid tile.
 
 The 3-bit field for pattern currently only has two encodings defined,
@@ -519,7 +519,7 @@ taking `pattern` mod 2, and taking the index within the pattern mod ETE.
 
 ===  Load/Store Tile Subset to Memory
 
-These instructions transfer tile subsets between the tile state and memory.
+These instructions transfer matrix tile subsets between the tile state and memory.
 `vtle` and `vtse` support TEW values corresponding to all
 supported SEW settings (8..ELEN).
 Implementations must provide vector loads and stores with EEWs corresponding
@@ -600,7 +600,7 @@ and detecting programming errors.
 
 === Move Tile Subset between Tile State and Vector Registers
 
-Tile subset operations transfer elements between a tile and a vector
+Tile subset operations transfer elements between a matrix tile and a vector
 register group.
 These instructions support TEW values corresponding to all
 supported SEW settings (8..ELEN).
@@ -628,7 +628,7 @@ For these instructions, the body elements are those with indices in the range
 === Matrix Arithmetic Instructions
 
 These instructions all have the form C += A^T * B, where C is held in
-a tile and A and B are supplied by vector register groups.
+a matrix tile and A and B are supplied by vector register groups.
 
 Unsupported `vtype` or `mtype` settings are reserved.
 An illegal-instruction exception is raised if `vstart` is nonzero.
@@ -722,13 +722,13 @@ implementation must support selecting `altfmt`=1 when SEW=8.
 
 The matrix arithmetic instructions are encoded in the second vector major opcode, OP-VE.
 
-The `rd` field encodes the accumulator tile, represented with `t` in the
+The `rd` field encodes the matrix tile number, represented with `t` in the
 diagram below.
 The tile-selection bits are allocated from the MSB of the `rd` field (e.g.
 TEW=32 operations have 4 tiles, requiring 2 bits, `t[3:2]`).
 Tile-selection bits not present in the instruction encoding are defined to be
 zero.
-If `t` encodes an invalid tile specifier, i.e. `t` modulo `(16 / #Tiles)` is
+If `t` encodes an invalid tile specifier, i.e. `t` modulo `(16 / NTiles)` is
 nonzero, the instruction is reserved.
 
 ----
@@ -744,7 +744,7 @@ nonzero, the instruction is reserved.
 === Matrix Tile-Zero Instruction
 
 The `vtzero` instruction writes 0 to each element of the `tm` by `tn`
-submatrix of the destination tile.
+submatrix of the destination matrix tile.
 Any tile elements outside the range [0, tm-1] x [0, tn-1] are
 considered part of the tail and are handled using a tail-agnostic
 policy.
@@ -766,7 +766,7 @@ The `mtype` CSR is considered part of the vector context; access to this
 CSR is controlled by the various `VS` fields.
 
 As described below, additional `MS` context-status fields are added to reduce
-the cost of saving and restoring the tile state.
+the cost of saving and restoring the matrix tile state.
 These fields do not affect accessibility of the `mtype` CSR.
 
 ==== Zvt Context Status in `mstatus`
@@ -775,7 +775,7 @@ A Zvt context status field, `MS`, is added to `mstatus[30:29]` and shadowed
 in `sstatus[30:29]`.  It is defined analogously to the floating-point context
 status field, `FS`.
 
-Attempts to execute any instruction that accesses the tile state raises an
+Attempts to execute any instruction that accesses the matrix tile state raises an
 illegal-instruction exception when `mstatus`.MS is set to Off.
 Note, the `vset*` and `mset*` instructions do not access the tile state.
 
@@ -794,7 +794,7 @@ is added to `vsstatus[30:29]`.
 It is defined analogously to the floating-point context status field, `FS`.
 
 When V=1, both `vsstatus`.MS and `mstatus`.MS are in effect: attempts to
-execute any instruction that accesses tile state raise an illegal-instruction
+execute any instruction that accesses matrix tile state raise an illegal-instruction
 exception when either field is set to Off.
 
 When V=1 and neither `vsstatus`.MS nor `mstatus`.MS is set to Off, executing
@@ -825,7 +825,7 @@ floating-point state.
 ----
 
 The `vtdiscard` instruction is provided to inform the runtime that
-the tile state is no longer useful and need not be saved.  `vtdiscard`
+the matrix tile state is no longer useful and need not be saved.  `vtdiscard`
 raises an illegal-instruction exception if `mstatus`.MS=Off (or if V=1
 and `vsstatus`.MS=Off).  Otherwise, it changes `mstatus`.MS to Initial
 (and, if V=1, changes `vsstatus`.MS to Initial).


### PR DESCRIPTION
- lg -> log2
- use "matrix tile" for first usage of the term within a section
- #Tiles -> NTiles